### PR TITLE
Fix for Issue #2380

### DIFF
--- a/src/progressbar/progressbar.component.ts
+++ b/src/progressbar/progressbar.component.ts
@@ -10,7 +10,7 @@ import { isBs3 } from '../utils';
           <ng-content></ng-content>
       </bar>
       <template [ngIf]="isStacked">
-        <bar *ngFor="let item of _value" [type]="item.type" [value]="item.value">{{item.label}}</bar>
+        <bar *ngFor="let item of _value" [type]="item.type" [value]="item.value" [max]="max">{{item.label}}</bar>
       </template>
     </div>
   `,


### PR DESCRIPTION
Fix for Issue #2380: pass the max value down to the bar component when using stacked instances so it knows how to properly calculate the width of each bar.